### PR TITLE
[FIX] Modify build script to not build client

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "server:start": "./node_modules/.bin/gulp build; concurrently -k \"nodemon dist/server/server.js\" \"gulp watch\"",
     "client:build": "./node_modules/.bin/webpack -p --config webpack/prod.config.js",
     "client:build:dev": "./node_modules/.bin/webpack --config webpack/dev.config.js;./node_modules/.bin/webpack --config webpack/dev.config.js --watch;",
-    "start:prod": "npm run client:build; node dist/server/server.js"
+    "start": "node dist/server/server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Heroku startup was taking too long so built client will need to be pushed for deploy